### PR TITLE
Add compilation flag to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC        = gcc
 EXEC      = slaMEM
-CFLAGS    = -Wall -Wextra -Wunused -mpopcnt
+CFLAGS    = -Wall -Wextra -Wunused -mpopcnt -fcommon
 CDEBUG    = -g -ggdb -fno-inline -dH -DGDB
 COPTIMIZE = -Wuninitialized -O9 -fomit-frame-pointer
 CLIBS     = -lm


### PR DESCRIPTION
Building on Linux (gcc for Ubuntu) threw an error due to multiple definitions of 'allSequences' and 'numSequences'. Adding the -fcommon flag, fixed it.